### PR TITLE
Fix garbled Windows interface names by using OEM codepage

### DIFF
--- a/socket_tools.py
+++ b/socket_tools.py
@@ -71,23 +71,34 @@ def is_windows() -> bool:
 # =========================
 def run_cmd(cmd: List[str], timeout: int = 30, encoding: Optional[str] = None) -> Tuple[int, str]:
     """
-    统一子进程执行：按指定编码解码，默认根据平台动态选择并容错，避免 GBK 相关报错。
+    统一子进程执行：按指定编码解码，默认根据平台动态选择并容错。
+    Windows 下改用 OEM 代码页以避免 netsh 等命令输出中文接口名时乱码。
     """
     if encoding is None:
-        if is_windows():
-            encoding = locale.getpreferredencoding(False) or "oem"
-        else:
-            encoding = "utf-8"
+        encoding = "oem" if is_windows() else "utf-8"
     try:
-        p = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            encoding=encoding,
-            errors="replace",
-            shell=False,
-        )
+        try:
+            p = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding=encoding,
+                errors="replace",
+                shell=False,
+            )
+        except LookupError:
+            # 某些平台可能不支持 "oem"，回退到本地默认编码
+            fallback = locale.getpreferredencoding(False) if is_windows() else "utf-8"
+            p = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding=fallback,
+                errors="replace",
+                shell=False,
+            )
         out, _ = p.communicate(timeout=timeout)
         return p.returncode, (out or "").strip()
     except Exception as e:


### PR DESCRIPTION
## Summary
- ensure subprocesses on Windows default to OEM codepage to avoid garbled interface names
- fallback to system encoding if OEM page is unavailable

## Testing
- `python -m py_compile socket_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6d6cde45c832fb901d35b70067994